### PR TITLE
Fix style of type declarations

### DIFF
--- a/build/dl-posters.ts
+++ b/build/dl-posters.ts
@@ -4,15 +4,15 @@ import * as request from "request";
 
 import { NUMBER_OF_MCU_MOVIES } from "../site/lib/constants";
 
-const ROOT_PATH : string = path.resolve(__dirname, "..");
+const ROOT_PATH: string = path.resolve(__dirname, "..");
 
-const BASE_DOWNLOAD_PATH : string = path.resolve(ROOT_PATH, "site", "assets", "img");
-const BASE_BUILD_PATH : string = path.resolve(ROOT_PATH, "build");
-const BASE_TEST_IMG_PATH : string = path.resolve(ROOT_PATH, "test", "assets", "img");
+const BASE_DOWNLOAD_PATH: string = path.resolve(ROOT_PATH, "site", "assets", "img");
+const BASE_BUILD_PATH: string = path.resolve(ROOT_PATH, "build");
+const BASE_TEST_IMG_PATH: string = path.resolve(ROOT_PATH, "test", "assets", "img");
 
-let files : string[] = fs.readdirSync(BASE_DOWNLOAD_PATH);
+let files: string[] = fs.readdirSync(BASE_DOWNLOAD_PATH);
 
-let fileMap : {[key : string] : boolean} = {};
+let fileMap: {[key: string]: boolean} = {};
 
 files.forEach((file) => {
     fileMap[file] = true;
@@ -20,22 +20,22 @@ files.forEach((file) => {
 
 for (let i = 1; i <= NUMBER_OF_MCU_MOVIES; i++) {
     // does the file exist in the images folder?
-    let filename : string = i.toString() + ".jpg";
+    let filename: string = i.toString() + ".jpg";
     if (fileMap[filename]) {
         console.log(i + " exists, skipping...");
     } else {
         // if not then if building for prod dl from imdb and put into images folder
         // if on test then copy test image into images folder instead
-        let destinationPath : string = path.resolve(BASE_DOWNLOAD_PATH, filename);
+        let destinationPath: string = path.resolve(BASE_DOWNLOAD_PATH, filename);
         if (process.env.NODE_ENV === "test") {
             console.log("Copying test poster to " + destinationPath);
             fs.promises.copyFile(path.resolve(BASE_TEST_IMG_PATH, "test.jpg"), destinationPath)
                 .then(() => console.log("Test poster copied to " + destinationPath))
                 .catch(() => console.error("Error copying poster to " + destinationPath))
         } else {
-            let downloadMapStr : Buffer = fs.readFileSync(path.resolve(BASE_BUILD_PATH, "movie_posters.json"));
-            let downloadMap : string = JSON.parse(downloadMapStr.toString());
-            let dlFilename : string = downloadMap[i];
+            let downloadMapStr: Buffer = fs.readFileSync(path.resolve(BASE_BUILD_PATH, "movie_posters.json"));
+            let downloadMap: string = JSON.parse(downloadMapStr.toString());
+            let dlFilename: string = downloadMap[i];
             console.log("Downloading poster " + dlFilename + " from IMDB to " + destinationPath + "...");
             request(dlFilename).pipe(fs.createWriteStream(destinationPath)).on("close", () => {
                 console.log("Downloaded poster to " + destinationPath);

--- a/site/App.vue
+++ b/site/App.vue
@@ -32,7 +32,7 @@ export default {
         }
     },
     methods: {
-        updateOrderingSelection: function(variable : string) {
+        updateOrderingSelection: function(variable: string) {
             this.selectedOrder = variable;
         }
     },

--- a/site/components/MCUMovieList.vue
+++ b/site/components/MCUMovieList.vue
@@ -41,15 +41,15 @@ export default class MCUMovieList extends MCUMovieListVue {
 
     show: any = (<Array<boolean>>new Array(this.movieModel.getNumberOfMovies())).fill(false);
     
-    get items () : Movie[] {
+    get items (): Movie[] {
         return this.movieModel.getMoviesByOrder(this.ordering);
     }
     
     created () {
-        for (let i : number = 0; i < this.movieModel.getNumberOfMovies(); i++) {
-            let initialSeconds : number = (200 * (i + 1));
-            let speedupFactor : number = 1 + (i / 14);
-            setTimeout((index : number) => {
+        for (let i: number = 0; i < this.movieModel.getNumberOfMovies(); i++) {
+            let initialSeconds: number = (200 * (i + 1));
+            let speedupFactor: number = 1 + (i / 14);
+            setTimeout((index: number) => {
                 Vue.set(this.show, index, true);
             }, initialSeconds / speedupFactor, i)
         }

--- a/site/components/MCUSelector.vue
+++ b/site/components/MCUSelector.vue
@@ -40,7 +40,7 @@ export default class MCUSelector extends MCUSelectorVue {
         return this.currentlySelected;
     }
 
-    set selected (value : string) {
+    set selected (value: string) {
         this.currentlySelected = value;
         this.movieModel.saveCurrentOrdering(value);
         this.$emit(UPDATE_ORDER_ACTION, value);

--- a/site/lib/MovieRepository.ts
+++ b/site/lib/MovieRepository.ts
@@ -45,7 +45,7 @@ export default class MovieRepository {
      * @param movieSeriesName movie series name to fetch current ordering for
      * @returns the current ordering of this movie series from storage
      */
-    public fetchCurrentOrdering(movieSeriesName : string): string {
+    public fetchCurrentOrdering(movieSeriesName: string): string {
         if (!isStorageAvailable(this.storage)) {
             throw new Error("Storage not available");
         }

--- a/site/lib/MovieSeries.ts
+++ b/site/lib/MovieSeries.ts
@@ -8,10 +8,10 @@ import { Movie, OrderingMap, WatchMap, MovieIdentifier } from "./types";
  */
 export default class MovieSeries {
 
-    private name : string;
-    private movies : Movie[];
-    private orderings : OrderingMap;
-    private repository : MovieRepository;
+    private name: string;
+    private movies: Movie[];
+    private orderings: OrderingMap;
+    private repository: MovieRepository;
 
     /**
      * Constructs a {@link MovieSeries} instance
@@ -21,7 +21,7 @@ export default class MovieSeries {
      * @param orderings a map of watch orders
      * @param repository high-level data repository
      */
-    public constructor(name : string, movies : Movie[], orderings : OrderingMap, repository : MovieRepository) {
+    public constructor(name: string, movies: Movie[], orderings: OrderingMap, repository: MovieRepository) {
         this.name = name;
         this.movies = movies;
         this.orderings = orderings;
@@ -33,7 +33,7 @@ export default class MovieSeries {
      * 
      * @returns number representing total number of movies
      */
-    public getNumberOfMovies() : number {
+    public getNumberOfMovies(): number {
         return this.movies.length;
     }
 
@@ -77,7 +77,7 @@ export default class MovieSeries {
      * 
      * @returns current ordering or empty string if no current ordering available
      */
-    public getCurrentOrderingName() : string {
+    public getCurrentOrderingName(): string {
         let currentOrdering: string = this.repository.fetchCurrentOrdering(this.name);
         return currentOrdering != null ? currentOrdering : "";
     }
@@ -87,7 +87,7 @@ export default class MovieSeries {
      * 
      * @returns map of movie ID to watched pairs
      */
-    public getMovieWatchedData() : WatchMap {
+    public getMovieWatchedData(): WatchMap {
         return this.repository.fetchMovieWatchData(this.generateMovieIdentifiers());
     }
 
@@ -97,7 +97,7 @@ export default class MovieSeries {
      * @param movieID ID of movie to update status for
      * @param watched whether this movie is now watched or not
      */
-    public saveWatchedStatus(movieID : number, watched : boolean) : void {
+    public saveWatchedStatus(movieID: number, watched: boolean): void {
         this.repository.saveWatchedStatus(this.name, movieID, watched);
     }
 
@@ -106,11 +106,11 @@ export default class MovieSeries {
      * 
      * @param orderingName name of new current ordering for this movie series
      */
-    public saveCurrentOrdering(orderingName : string) : void {
+    public saveCurrentOrdering(orderingName: string): void {
         this.repository.saveCurrentOrdering(this.name, orderingName);
     }
 
-    private generateMovieIdentifiers() : MovieIdentifier[] {
+    private generateMovieIdentifiers(): MovieIdentifier[] {
         return this.movies.map((movie) => {
             return {
                 storageID: createMovieStorageIdentifier(this.name, movie.id),

--- a/site/lib/types.ts
+++ b/site/lib/types.ts
@@ -31,5 +31,5 @@ export type WatchMap = { [movieID: number]: boolean };
  */
 export type MovieIdentifier = {
     storageID: string,
-    id : number
+    id: number
 };

--- a/site/lib/util.ts
+++ b/site/lib/util.ts
@@ -7,7 +7,7 @@
  * @param storage storage to check
  * @returns whether this storage is available to use
  */
-export function isStorageAvailable(storage : Storage): boolean {
+export function isStorageAvailable(storage: Storage): boolean {
     try {
         let x: string = "__storage_test__";
         storage.setItem(x, x);
@@ -36,7 +36,7 @@ export function isStorageAvailable(storage : Storage): boolean {
  * @param movieID ID of movie
  * @returns movie identifier string
  */
-export function createMovieStorageIdentifier(movieSeriesName : string, movieID : number) : string {
+export function createMovieStorageIdentifier(movieSeriesName: string, movieID: number): string {
     return movieSeriesName + "." + movieID;
 };
 
@@ -46,6 +46,6 @@ export function createMovieStorageIdentifier(movieSeriesName : string, movieID :
  * @param movieSeriesName movie series name
  * @returns movie ordering identifier string
  */
-export function createMovieOrderingIdentifier(movieSeriesName : string) {
+export function createMovieOrderingIdentifier(movieSeriesName: string) {
     return movieSeriesName + ".ordering";
 };

--- a/test/MCUMovie.spec.ts
+++ b/test/MCUMovie.spec.ts
@@ -21,7 +21,7 @@ describe("MCUMovie", () => {
     });
 
     it("should have the 'movie' class", () => {
-        let imgElem : Wrapper<Vue> = wrapper.find("img");
+        let imgElem: Wrapper<Vue> = wrapper.find("img");
 
         expect(imgElem.classes()).to.contain("movie");
     });
@@ -33,7 +33,7 @@ describe("MCUMovie", () => {
 
         await Vue.nextTick();
 
-        let imgElem : Wrapper<Vue> = wrapper.find("img");
+        let imgElem: Wrapper<Vue> = wrapper.find("img");
 
         expect(imgElem.classes()).to.contain("grayscale");
     });
@@ -66,9 +66,9 @@ describe("MCUMovie", () => {
     });
 
     describe("toggleWatch", () => {
-        const MOVIE_ID_FIXTURE : number = 5;
+        const MOVIE_ID_FIXTURE: number = 5;
 
-        let movieSeriesMock : SinonMock;
+        let movieSeriesMock: SinonMock;
 
         beforeEach(() => {
             wrapper.setProps({

--- a/test/MCUMovieList.spec.ts
+++ b/test/MCUMovieList.spec.ts
@@ -8,10 +8,10 @@ import MovieSeries from "../site/lib/MovieSeries";
 describe("MCUMovieList", () => {
     let wrapper: Wrapper<MCUMovieList>;
 
-    let movieModelStub : MovieSeries;
-    let mockGetMovieWatchedData : SinonStub;
+    let movieModelStub: MovieSeries;
+    let mockGetMovieWatchedData: SinonStub;
 
-    const TEST_MOVIES : Movie[] = [
+    const TEST_MOVIES: Movie[] = [
         {
             title: "Movie 1",
             id: 1
@@ -22,7 +22,7 @@ describe("MCUMovieList", () => {
         }
     ];
 
-    const TEST_ORDERINGS : OrderingMap = {
+    const TEST_ORDERINGS: OrderingMap = {
         "test": [1,2]
     };
 
@@ -38,7 +38,7 @@ describe("MCUMovieList", () => {
             },
             computed: {
                 items: function() {
-                    return TEST_MOVIES.map((elem : any) => {
+                    return TEST_MOVIES.map((elem: any) => {
                         return elem;
                     });
                 }
@@ -68,7 +68,7 @@ describe("MCUMovieList", () => {
             }
         });
 
-        TEST_MOVIES.forEach((elem : Movie, index) => {
+        TEST_MOVIES.forEach((elem: Movie, index) => {
             expect(wrapper.vm.items[index].id).to.equal(elem.id);
         });
     });

--- a/test/MCUSelector.spec.ts
+++ b/test/MCUSelector.spec.ts
@@ -11,11 +11,11 @@ import * as sinon from "sinon";
 const test = sinonTest.configureTest(sinon);
 
 describe("MCUSelector", () => {
-    let wrapper : Wrapper<MCUSelector>;
+    let wrapper: Wrapper<MCUSelector>;
 
-    let movieModelStub : MovieSeries;
+    let movieModelStub: MovieSeries;
 
-    const TEST_OPTIONS : string[] = ["test1", "test2"];
+    const TEST_OPTIONS: string[] = ["test1", "test2"];
 
     beforeEach(test(async function() {
         movieModelStub = new MovieSeries("test", [], {}, null);
@@ -39,7 +39,7 @@ describe("MCUSelector", () => {
     });
 
     it("should populate the dropdown with options", () => {
-        let resultArr : WrapperArray<Vue> = wrapper.findAll("option");
+        let resultArr: WrapperArray<Vue> = wrapper.findAll("option");
 
         expect(resultArr.length).to.equal(TEST_OPTIONS.length);
 
@@ -49,7 +49,7 @@ describe("MCUSelector", () => {
     });
 
     it("should invoke save operation for correct ordering preference when selected", test(function() {
-        let saveOrderingStub : SinonStub = this.stub(MovieSeries.prototype, "saveCurrentOrdering");
+        let saveOrderingStub: SinonStub = this.stub(MovieSeries.prototype, "saveCurrentOrdering");
         
         const OPTION_TO_SAVE: string = TEST_OPTIONS[1];
 
@@ -58,7 +58,7 @@ describe("MCUSelector", () => {
         
         expect(saveOrderingStub.callCount).to.equal(1);
         
-        let firstCallArgs : any[] = saveOrderingStub.args[0];
+        let firstCallArgs: any[] = saveOrderingStub.args[0];
         expect(firstCallArgs.length).to.equal(1);
         expect(firstCallArgs[0]).to.equal(OPTION_TO_SAVE, "did not invoke save for the correct ordering");
     }));
@@ -72,12 +72,12 @@ describe("MCUSelector", () => {
     }));
 });
 
-function verifyMCUSelectorCurrentlySelected(wrapper : Wrapper<Vue>, sandbox : SinonSandbox, optionFixtures : string[], mockedVerifyResult : boolean) : void {
+function verifyMCUSelectorCurrentlySelected(wrapper: Wrapper<Vue>, sandbox: SinonSandbox, optionFixtures: string[], mockedVerifyResult: boolean): void {
     let verifyStub: SinonStub = sandbox.stub(MovieSeries.prototype, "verifyOrdering");
     let orderingStub: SinonStub = sandbox.stub(MovieSeries.prototype, "getCurrentOrderingName");
-    let orderingOptionsStub : SinonStub = sandbox.stub(MovieSeries.prototype, "getOrderingOptions");
+    let orderingOptionsStub: SinonStub = sandbox.stub(MovieSeries.prototype, "getOrderingOptions");
 
-    const CURR_SELECTED : string = optionFixtures[0];
+    const CURR_SELECTED: string = optionFixtures[0];
 
     verifyStub.returns(mockedVerifyResult);
     orderingStub.returns(CURR_SELECTED);

--- a/test/MovieRepository.spec.ts
+++ b/test/MovieRepository.spec.ts
@@ -20,24 +20,24 @@ class MockStorage implements Storage {
 
 const REAL_IS_STORAGE_AVAILABLE = require.cache[require.resolve("../site/lib/util")].exports.isStorageAvailable;
 
-function mockIsStorageAvailable(result : boolean) : void {
+function mockIsStorageAvailable(result: boolean): void {
     const isStorageAvailableStub = stub();
     isStorageAvailableStub.returns(result);
 
     require.cache[require.resolve("../site/lib/util")].exports.isStorageAvailable = isStorageAvailableStub;
 }
 
-function clearIsStorageAvailableMock() : void {
+function clearIsStorageAvailableMock(): void {
     require.cache[require.resolve("../site/lib/util")].exports.isStorageAvailable = REAL_IS_STORAGE_AVAILABLE;
 }
 
 describe("MovieRepository", () => {
 
-    let movieRepository : MovieRepository;
-    let storage : MockStorage;
-    let storageMock : SinonMock;
+    let movieRepository: MovieRepository;
+    let storage: MockStorage;
+    let storageMock: SinonMock;
 
-    const MOVIE_SERIES_NAME : string = "movie-series";
+    const MOVIE_SERIES_NAME: string = "movie-series";
 
     beforeEach(() => {
         storageMock = mock(MockStorage.prototype);
@@ -47,22 +47,22 @@ describe("MovieRepository", () => {
     
     describe("fetchMovieWatchData", () => {
         const MOVIE_ID = 1;
-        const EXPECTED_ARG : string = createMovieStorageIdentifier(MOVIE_SERIES_NAME, MOVIE_ID);
+        const EXPECTED_ARG: string = createMovieStorageIdentifier(MOVIE_SERIES_NAME, MOVIE_ID);
         const EXPECTED_RET_VALUE: string = "true";
-        const MOVIE_IDENTIFIERS_FIXTURE : MovieIdentifier[] = [
+        const MOVIE_IDENTIFIERS_FIXTURE: MovieIdentifier[] = [
             {
                 id: MOVIE_ID,
                 storageID: EXPECTED_ARG
             }
         ];
-        const WATCH_MAP_FIXTURE : WatchMap = {
+        const WATCH_MAP_FIXTURE: WatchMap = {
             [1]: true
         };
 
         it("should get the movie watch data from storage", () => {
             storageMock.expects("getItem").once().withExactArgs(EXPECTED_ARG).returns(EXPECTED_RET_VALUE);
 
-            let watchInfo : WatchMap = movieRepository.fetchMovieWatchData(MOVIE_IDENTIFIERS_FIXTURE);
+            let watchInfo: WatchMap = movieRepository.fetchMovieWatchData(MOVIE_IDENTIFIERS_FIXTURE);
 
             storageMock.verify();
             expect(Object.keys(watchInfo).length).to.equal(1);
@@ -95,7 +95,7 @@ describe("MovieRepository", () => {
         it("should have watch data of false if null is returned from storage", () => {
             storageMock.expects("getItem").once().withExactArgs(EXPECTED_ARG).returns(null);
 
-            let watchInfo : WatchMap = movieRepository.fetchMovieWatchData(MOVIE_IDENTIFIERS_FIXTURE);
+            let watchInfo: WatchMap = movieRepository.fetchMovieWatchData(MOVIE_IDENTIFIERS_FIXTURE);
 
             storageMock.verify();
             expect(Object.keys(watchInfo).length).to.equal(1);
@@ -109,13 +109,13 @@ describe("MovieRepository", () => {
     });
 
     describe("fetchCurrentOrdering", () => {
-        const EXPECTED_ARG : string = createMovieOrderingIdentifier(MOVIE_SERIES_NAME);
-        const ORDERING_FIXTURE : string = "my-ordering";
+        const EXPECTED_ARG: string = createMovieOrderingIdentifier(MOVIE_SERIES_NAME);
+        const ORDERING_FIXTURE: string = "my-ordering";
 
         it("should get the current ordering name from storage", () => {
             storageMock.expects("getItem").once().withExactArgs(EXPECTED_ARG).returns(ORDERING_FIXTURE);
             
-            let currOrdering : string = movieRepository.fetchCurrentOrdering(MOVIE_SERIES_NAME);
+            let currOrdering: string = movieRepository.fetchCurrentOrdering(MOVIE_SERIES_NAME);
 
             storageMock.verify();
             expect(currOrdering).to.equal(ORDERING_FIXTURE);
@@ -151,8 +151,8 @@ describe("MovieRepository", () => {
     });
 
     describe("saveWatchedStatus", () => {
-        const MOVIE_ID : number = 1;
-        const WATCHED_STATUS_FIXTURE : boolean = true;
+        const MOVIE_ID: number = 1;
+        const WATCHED_STATUS_FIXTURE: boolean = true;
         const EXPECTED_ARGS: string[] = [createMovieStorageIdentifier(MOVIE_SERIES_NAME, MOVIE_ID), WATCHED_STATUS_FIXTURE.toString()];
         
         it("should save watch data to storage", () => {

--- a/test/MovieSeries.spec.ts
+++ b/test/MovieSeries.spec.ts
@@ -13,7 +13,7 @@ const STORAGE_NOT_AVAILABLE_MESSAGE = "storage not available";
 
 describe("MovieSeries", () => {
 
-    const MOVIE_SERIES_NAME_FIXTURE : string = "test";
+    const MOVIE_SERIES_NAME_FIXTURE: string = "test";
     const FIRST_MOVIE: Movie = {
         title: "Test",
         id: 1
@@ -24,12 +24,12 @@ describe("MovieSeries", () => {
     };
     const DEFAULT_ORDER_NAME = "release";
     const ALTERNATIVE_ORDER_NAME = "another-ordering";
-    const MOVIES_FIXTURE : Movie[] = [FIRST_MOVIE, SECOND_MOVIE];
-    const ORDERINGS_FIXTURE : OrderingMap = {
+    const MOVIES_FIXTURE: Movie[] = [FIRST_MOVIE, SECOND_MOVIE];
+    const ORDERINGS_FIXTURE: OrderingMap = {
         [DEFAULT_ORDER_NAME]: [1,2],
         [ALTERNATIVE_ORDER_NAME]: [2,1]
     };
-    const MOVIE_REPOSITORY_MOCK : MovieRepository = new MovieRepository(null);
+    const MOVIE_REPOSITORY_MOCK: MovieRepository = new MovieRepository(null);
 
     let movieSeries: MovieSeries;
 
@@ -63,7 +63,7 @@ describe("MovieSeries", () => {
         });
 
         it("should return empty array if attempting to get movies by an ordering that does not exist", () => {
-            let movieSeq : any[];
+            let movieSeq: any[];
 
             try {
                 movieSeq = movieSeries.getMoviesByOrder("not-an-ordering");
@@ -92,7 +92,7 @@ describe("MovieSeries", () => {
 
     describe("getCurrentOrderingName", () => {
         it("should get movie ordering preference from repository", test(function() {
-            let fetchMovieOrderingStub : SinonStub = this.stub(MovieRepository.prototype, "fetchCurrentOrdering");
+            let fetchMovieOrderingStub: SinonStub = this.stub(MovieRepository.prototype, "fetchCurrentOrdering");
             fetchMovieOrderingStub.returns(DEFAULT_ORDER_NAME);
 
             expect(movieSeries.getCurrentOrderingName()).to.equal(DEFAULT_ORDER_NAME);
@@ -115,7 +115,7 @@ describe("MovieSeries", () => {
 
     describe("getMovieWatchedData", () => {
         it("should get watch data for all movies from repository", test(function() {
-            let fetchMovieDataStub : SinonStub = this.stub(MovieRepository.prototype, "fetchMovieWatchData");
+            let fetchMovieDataStub: SinonStub = this.stub(MovieRepository.prototype, "fetchMovieWatchData");
             fetchMovieDataStub.returns(MOVIES_FIXTURE.reduce((obj, currVal): WatchMap => {
                 obj[currVal.id] = true;
                 return obj;
@@ -138,7 +138,7 @@ describe("MovieSeries", () => {
 
     describe("saveMCUStatus", () => {
         it("should save watched status of a movie to repository", test(function() {
-            let saveWatchedStatusMock : SinonMock = this.mock(MovieRepository.prototype);
+            let saveWatchedStatusMock: SinonMock = this.mock(MovieRepository.prototype);
 
             saveWatchedStatusMock.expects("saveWatchedStatus").once().withExactArgs(MOVIE_SERIES_NAME_FIXTURE, FIRST_MOVIE.id, true);
 
@@ -163,7 +163,7 @@ describe("MovieSeries", () => {
 
     describe("saveCurrentOrdering", () => {
         it("should save movie ordering preference to repository", test(function() {
-            let saveOrderingMock : SinonMock = this.mock(MovieRepository.prototype);
+            let saveOrderingMock: SinonMock = this.mock(MovieRepository.prototype);
 
             saveOrderingMock.expects("saveCurrentOrdering").once().withExactArgs(MOVIE_SERIES_NAME_FIXTURE, ALTERNATIVE_ORDER_NAME);
 


### PR DESCRIPTION
Make all type declaration style consistent by removing any spaces in between variable names and colons. This is to my knowledge how's it usually stylized in practice.

Example: From `let myVar : string` to `let myVar: string`