### PR TITLE
Split webpack bundles and change source map devtool 

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-var webpackConfig = require("./webpack.config.js");
+const webpackConfig = require("./webpack.config.js");
 
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 
@@ -9,7 +9,13 @@ module.exports = function(config) {
         preprocessors: {
             "**/*.spec.ts": ["webpack", "sourcemap"]
         },
-        webpack: webpackConfig,
+        webpack: Object.assign(webpackConfig, {
+            optimization: {
+                splitChunks: {
+                    chunks: "async"
+                }
+            }
+        }),
         reporters: ["spec", "junit"],
         browsers: ["ChromeHeadless"],
         junitReporter: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "ts-node app.ts",
-    "build": "webpack --verbose",
+    "build": "webpack",
     "vuetype": "vuetype site/components",
     "dl-posters": "ts-node build/dl-posters.ts",
     "full-build": "npm run dl-posters && npm run build",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,9 @@ const VueLoaderPlugin = require("vue-loader/lib/plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
+const PROD_DEVTOOL = "source-map";
+const DEV_DEVTOOL = "cheap-module-eval-source-map";
+
 function getWebpackMode(nodeEnv) {
     if (!nodeEnv || (nodeEnv !== "production" && nodeEnv !== "none")) {
         return "development";
@@ -10,10 +13,14 @@ function getWebpackMode(nodeEnv) {
     return nodeEnv;
 }
 
+function isProduction(nodeEnv) {
+    return nodeEnv === "production";
+}
+
 module.exports = {
     entry: "./site/index.ts",
     mode: getWebpackMode(process.env.NODE_ENV),
-    devtool: "inline-source-map",
+    devtool: isProduction(process.env.NODE_ENV) ? PROD_DEVTOOL : DEV_DEVTOOL,
     module: {
         rules: [
             {
@@ -61,5 +68,16 @@ module.exports = {
             }
         ]),
         new VueLoaderPlugin()
-    ]
+    ],
+    optimization: {
+        splitChunks: {
+            chunks: "all",
+            cacheGroups: {
+                node: {
+                    name: "node_modules",
+                    test: /node_modules/
+                }
+            }
+        }
+    }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,13 +71,7 @@ module.exports = {
     ],
     optimization: {
         splitChunks: {
-            chunks: "all",
-            cacheGroups: {
-                node: {
-                    name: "node_modules",
-                    test: /node_modules/
-                }
-            }
+            chunks: "all"
         }
     }
 };


### PR DESCRIPTION
Fixes #13 

Use webpack v4's `SplitChunksPlugin` to split the build into two chunks, one for main (containing the mcu-rewatch front-end code) and the other for vendors (which are the node_modules that get bundled). The default options [shown here](https://webpack.js.org/plugins/split-chunks-plugin/) are good enough for the time being (`chunks: 'async'` has been changed to `chunks: 'all'` so not just async chunks such as dynamic imports are split).

Also, change the source map tool from `inline-source-map` to `cheap-module-eval-source-map` for development builds for better performance, and to `source-map` for production builds to move all source map content into separate .map files for significantly reduced bundle sizes.

This is enough to push the bundles well below webpack's recommended 244 KiB limit for bundle sizes. I will probably need dynamic imports for future additions to mcu-rewatch down the line, which will require some more updates to `webpack.config.js`, `tsconfig.json`, and other files. However, nothing more needs to be done to fix the problem I described in the issue.

Also fixed an oddity with karma test runner where it wasn't liking the new `optimization.splitChunks` option. Fixed this problem by setting the `chunks` option back to `async` for tests.