### PR TITLE
Update sinon-test type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -973,9 +973,9 @@
       }
     },
     "@types/sinon-test": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/sinon-test/-/sinon-test-1.0.7.tgz",
-      "integrity": "sha512-JNxk5VmtaPnzitDxGb7T6qaiZae0ogn7hAMZBWixwyXVA9bAPrniRC9moPP3kfYPmebkqo6MFGfb9/bCFEeOKA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon-test/-/sinon-test-2.4.0.tgz",
+      "integrity": "sha512-YW723M2ZdAuaAzZImRv9ujoXqqtjrwYFPG0m9t5lnnKZH9w0hbZGDeSjCcVcPZ83hsVKJvQnsDa3KQZvgkkTew==",
       "dev": true,
       "requires": {
         "@types/sinon": "*"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/request": "^2.48.1",
     "@types/sinon": "^7.0.11",
     "@types/sinon-chai": "^3.2.2",
-    "@types/sinon-test": "^1.0.7",
+    "@types/sinon-test": "^2.4.0",
     "@vue/test-utils": "^1.0.0-beta.29",
     "babel-loader": "^8.0.5",
     "chai": "^4.2.0",

--- a/test/MCUSelector.spec.ts
+++ b/test/MCUSelector.spec.ts
@@ -8,7 +8,7 @@ import { DEFAULT_MCU_ORDER } from "../site/lib/constants";
 import * as sinonTest from "sinon-test";
 import * as sinon from "sinon";
 
-const test = sinonTest.configureTest(sinon);
+const test = sinonTest(sinon);
 
 describe("MCUSelector", () => {
     let wrapper: Wrapper<MCUSelector>;

--- a/test/MovieSeries.spec.ts
+++ b/test/MovieSeries.spec.ts
@@ -7,7 +7,7 @@ import MovieRepository from "../site/lib/MovieRepository";
 import { Movie, WatchMap } from "../site/lib/types";
 import { OrderingMap } from "../site/lib/types";
 
-const test = sinonTest.configureTest(sinon);
+const test = sinonTest(sinon);
 
 const STORAGE_NOT_AVAILABLE_MESSAGE = "storage not available";
 


### PR DESCRIPTION
(If I'm not mistaken) `sinon-test` will soon be deprecating `sinonTest.configureTest` in favour of simply `sinonTest`, so update the type definition file and the calls accordingly.