### PR TITLE
Update node.js CircleCI image to latest LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.10-browsers
+      - image: cimg/node:14.17.0-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
https://circleci.com/developer/images/image/cimg/node

Looks like CircleCI Node 8 image no longer works with CI build. https://app.circleci.com/pipelines/github/Coteh/mcu-rewatch/288/workflows/e0fc55bb-41cb-4ef0-8424-75c9727e7129/jobs/289

Update to latest Docker image with latest LTS release of Node.